### PR TITLE
feat(crear-skin): implementa selectores de color y slider de altura

### DIFF
--- a/src/components/SkinCustomizer/ColorPalette.jsx
+++ b/src/components/SkinCustomizer/ColorPalette.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const ColorPalette = ({
+  title,
+  subtitle,
+  colors,
+  selectorColor,
+  onColorSelect,
+}) => {
+  return (
+    <div>
+      <h3
+        className="text-lg font-bold mb-3 flex justify-between items-center text-[#000000]"
+        style={{ textShadow: "none" }}
+      >
+        <span>{title}</span>
+        <span className="text-sm font-normal text-[#9ca3af] border-2 border-[#9ca3af] px-2 py-1">
+          #HEX
+        </span>
+      </h3>
+
+      <div className="flex gap-2">
+        {colors.map((color) => (
+          <button
+            key={color}
+            onClick={() => onColorSelect(color)}
+            className={`w-10 h-11 md:w-12 md:h-12 border-2 rounded-lg transition-all hover:scale-110 ${
+              selectorColor === color
+                ? "border-[#4d924c] shadow-[inset_0px_0px_0px_2px_white]"
+                : "border-[#000000] opacity-80 hover:opacity-100"
+            }`}
+            style={{ backgroundColor: color }}
+            title={`${title}: ${color}`}
+          >
+            {selectorColor === color && (
+              <span className="flex items-center justify-center h-full text-white drop-shadow-md font-bold text-sm"></span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {subtitle && <p className="text-sm text-[#9ca3af] mt-2">{subtitle}</p>}
+    </div>
+  );
+};
+
+export default ColorPalette;

--- a/src/components/SkinCustomizer/HeightSlider.jsx
+++ b/src/components/SkinCustomizer/HeightSlider.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const HeightSlider = ({ value, onChange }) => {
+  return (
+    <div className="w-full">
+      <h3
+        className="text-lg font-bold mb-4 flex items-center gap-2 text-[#000000]"
+        style={{ textShadow: "none" }}
+      >
+        <span>🧍</span> Altura del personaje
+      </h3>
+
+      <div className="relative flex items-center py-4">
+        <input
+          type="range"
+          min="20"
+          max="100"
+          value={value || 50}
+          onChange={(e) => onChange(parseInt(e.target.value))}
+          className="w-full h-4 bg-[#e5e7eb] border-[#000000] appearance-none cursor-pointer accent-[#4d924c] rounded-none shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]"
+          style={{ imageRendering: "pixelated" }}
+        />
+      </div>
+
+      <div className="flex justify-between text-sm font-bold text-[#9ca3af] mt-1">
+        <span className={value < 40 ? "text-black" : ""}>Bajo</span>
+        <span className={value >= 40 && value <= 70 ? "text-[#4d924c]" : ""}>
+          Medio
+        </span>
+        <span className={value > 70 ? "text-black" : ""}>Alto</span>
+      </div>
+    </div>
+  );
+};
+
+export default HeightSlider;

--- a/src/components/SkinCustomizer/SkinCustomizer.jsx
+++ b/src/components/SkinCustomizer/SkinCustomizer.jsx
@@ -1,49 +1,43 @@
 import React from "react";
+import ColorPalette from "./ColorPalette";
+import HeightSlider from "./HeightSlider";
+
+const SKIN_COLORS = ["#FFD6A5", "#F5C293", "#D2A679", "#8D5524", "#4A3018"];
+const HAIR_COLORS = ["#F4C753", "#D26015", "#5E3A1B", "#1f1f1f", "#f0f0f0"];
 
 const SkinCustomizer = ({ currentSkin, onUpdateSkin }) => {
+  const handleChange = (attribute, value) => {
+    onUpdateSkin((prev) => ({
+      ...prev,
+      [attribute]: value,
+    }));
+  };
   return (
     <div className="flex flex-col gap-8 bg-[#ffffff] p-6 border-4 border-[#000000] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
       {/* Seccion de color de piel y pelo */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
-          <h3 className="text-lg font-bold mb-3 flex justify-between items-center text-[#000000]">
-            <span>Color de piel</span>
-            <span className="text-sm font-normal text-[#9ca3af] border-2 border-[#9ca3af] px-2 py-1">
-              #HEX
-            </span>
-          </h3>
-          {/* Cuadraditos */}
+        <ColorPalette
+          title="Color de piel"
+          colors={SKIN_COLORS}
+          selectorColor={currentSkin?.skinColor}
+          onColorSelect={(color) => handleChange("skinColor", color)}
+        />
 
-          <p className="text-sm text-[#9ca3af] mt-2">
-            De mas claro a mas oscuro
-          </p>
-        </div>
-
-        <div>
-          <h3 className="text-lg font-bold mb-3 flex justify-between items-center text-[#000000]">
-            <span>Color de pelo</span>
-            <span className="text-sm font-normal text-[#9ca3af] border-2 border-[#9ca3af] px-2 py-1">
-              #HEX
-            </span>
-          </h3>
-          {/* Aca van los cuadraditos */}
-        </div>
+        <ColorPalette
+          title="Color de pelo"
+          colors={HAIR_COLORS}
+          selectorColor={currentSkin?.hairColor}
+          onColorSelect={(color) => handleChange("hairColor", color)}
+        />
       </div>
 
       <hr className="border-2 border-dashed border-[#9ca3af]" />
 
       {/* Altura */}
-      <div>
-        <h3 className="text-lg font-bold mb-4 flex items-center gap-2 text-[#000000]">
-          <span>🧍</span> Altura del personaje
-        </h3>
-        {/* Input range */}
-        <div className="flex justify-between text-sm font-bold text-[#9ca3af] mt-2">
-          <span>Bajo</span>
-          <span className="text-[#4d924c]">Medio</span>
-          <span>Alto</span>
-        </div>
-      </div>
+      <HeightSlider
+        value={currentSkin?.height}
+        onChange={(val) => handleChange("height", val)}
+      />
 
       <hr className="border-2 border-dashed border-[#9ca3af]" />
 

--- a/src/pages/CreateSkin/CreateSkin.jsx
+++ b/src/pages/CreateSkin/CreateSkin.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import SkinCustomizer from "../../components/SkinCustomizer/SkinCustomizer";
-import imgCreeper from "../../assets/icons/Creeper_Head.png";
+import Alex from "../../assets/icons/alex_head.png";
 
 const CreateSkin = () => {
   const [currentSkin, setCurrentSkin] = useState({
@@ -11,15 +11,15 @@ const CreateSkin = () => {
   return (
     <div className="max-w-7xl mx-auto p-4 md:p-8">
       <h1
-        className="text-4xl md:text-5xl font-black mb-8 text-[#000000] uppercase flex items-center gap-4"
+        className=" text-4xl md:text-5xl font-black mb-8 text-[#000000] uppercase flex items-center gap-4"
         style={{ textShadow: "none" }}
       >
-        <img src={imgCreeper} alt="Creeper" className="w-10 h-10 pixelated" />
+        <img src={Alex} alt="Alex" className="w-10 h-10 pixelated" />
         Crea tu skin
       </h1>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8 items-start">
-        <div className="md:col-span-1 bg-gradient-to-b from-[#e5f0f9] to-[#d4e5d3] border-4 border-[#000000] p-6 flex flex-col items-center justify-center min-h-[500px] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] sticky top-4 rounded-lg">
+        <div className="md:col-span-1 bg-gradient-to-b from-[#e5f0f9] to-[#d4e5d3] border-4 border-[#000000] p-6 flex flex-col items-center justify-center min-h-[500px] shadow-[8px_8px_0px_0px_rgba(0,0,0,1)] top-4 rounded-lg">
           <div className="w-full text-left mb-auto">
             <h2
               className="text-xl font-bold text-black"


### PR DESCRIPTION
- _Se maquetó la estructura base de la página CreateSkin_.
- _Se creó el componente SkinCustomizer para centralizar los controles._
- _Se modularizó la lógica en ColorPalette.jsx para evitar repetición de código._
- _Se implementó HeightSlider.jsx con estilos retro adaptados a la UI de Minecraft._
- _Se configuró el estado inicial y la comunicación por props con el componente Padre._