### PR TITLE
feat: implementar wrapper fetchWithAuth para inyección automática de JWT (#83)

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,17 +1,13 @@
 import { createContext, useContext, useState, useEffect } from "react";
 
-// 1. Crear el contexto de autenticación
 const AuthContext = createContext();
 
-// 2. Crear el proveedor del contexto (Provider)
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
   const [token, setToken] = useState(localStorage.getItem("token") || null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // Auto-login simulado: si al cargar la app ya existe un token en localStorage,
-  // restauramos un usuario simulado según el tipo de token.
   useEffect(() => {
     if (token) {
       setIsLoading(true);
@@ -24,12 +20,11 @@ export const AuthProvider = ({ children }) => {
           role,
         });
         setIsLoading(false);
-      }, 500); // Pequeña demora para simular la velocidad de la API
+      }, 500);
       return () => clearTimeout(timer);
     }
   }, [token]);
 
-  // Función de inicio de sesión simulada
   const login = async (email, password) => {
     setIsLoading(true);
     setError(null);
@@ -43,9 +38,10 @@ export const AuthProvider = ({ children }) => {
           return;
         }
 
-        // Simulación: Si el email es admin@admin.com, inicia como administrador.
-        const role = email.toLowerCase() === "admin@admin.com" ? "ADMIN" : "CLIENT";
-        const mockToken = role === "ADMIN" ? "mock-jwt-token-admin" : "mock-jwt-token-client";
+        const role =
+          email.toLowerCase() === "admin@admin.com" ? "ADMIN" : "CLIENT";
+        const mockToken =
+          role === "ADMIN" ? "mock-jwt-token-admin" : "mock-jwt-token-client";
         const mockUser = {
           id: "mock-user-123",
           name: role === "ADMIN" ? "Admin Erick" : "Cliente Erick",
@@ -53,7 +49,6 @@ export const AuthProvider = ({ children }) => {
           role,
         };
 
-        // Guardamos el token en localStorage para la persistencia
         localStorage.setItem("token", mockToken);
         setToken(mockToken);
         setUser(mockUser);
@@ -63,7 +58,6 @@ export const AuthProvider = ({ children }) => {
     });
   };
 
-  // Función de registro simulada
   const register = async (name, email, password) => {
     setIsLoading(true);
     setError(null);
@@ -83,7 +77,6 @@ export const AuthProvider = ({ children }) => {
     });
   };
 
-  // Función de cierre de sesión simulada
   const logout = async () => {
     setIsLoading(true);
     return new Promise((resolve) => {
@@ -97,15 +90,15 @@ export const AuthProvider = ({ children }) => {
     });
   };
 
-  // Retornamos el proveedor con el estado y las funciones disponibles
   return (
-    <AuthContext.Provider value={{ user, token, isLoading, error, login, register, logout }}>
+    <AuthContext.Provider
+      value={{ user, token, isLoading, error, login, register, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );
 };
 
-// 3. Hook personalizado para consumir el contexto fácilmente
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,22 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
+const fetchWithAuth = async (urlSuffix, options = {}) => {
+  const token = localStorage.getItem("token");
+
+  const header = {
+    ...options.headers,
+  };
+
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  return fetch(`${API_URL}/${urlSuffix}`, {
+    ...options,
+    headers,
+  });
+};
+
 const mapEntity = (entidad, data) => {
   if (!data) return null;
 
@@ -31,14 +48,14 @@ const mapEntity = (entidad, data) => {
 };
 
 export const getAll = async (entidad) => {
-  const response = await fetch(`${API_URL}/${entidad}`);
+  const response = await fetchWithAuth(entidad);
   if (!response.ok) throw new Error(`Error al obtener los datos de ${entidad}`);
   const list = await response.json();
   return list.map((item) => mapEntity(entidad, item));
 };
 
 export const getById = async (entidad, id) => {
-  const response = await fetch(`${API_URL}/${entidad}/${id}`);
+  const response = fetchWithAuth(entidad / { id });
   if (!response.ok)
     throw new Error(`Error al obtener el registro de ${entidad}`);
   const data = await response.json();
@@ -46,7 +63,7 @@ export const getById = async (entidad, id) => {
 };
 
 export const create = async (entidad, data) => {
-  const response = await fetch(`${API_URL}/${entidad}`, {
+  const response = await fetchWithAuth(entidad, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -67,7 +84,7 @@ export const create = async (entidad, data) => {
 };
 
 export const update = async (entidad, id, data) => {
-  const response = await fetch(`${API_URL}/${entidad}/${id}`, {
+  const response = await fetchWithAuth(`${entidad}/${id}`, {
     method: "PUT",
     headers: {
       "Content-Type": "application/json",
@@ -80,7 +97,7 @@ export const update = async (entidad, id, data) => {
 };
 
 export const remove = async (entidad, id) => {
-  const response = await fetch(`${API_URL}/${entidad}/${id}`, {
+  const response = await fetchWithAuth(`${entidad}/${id}`, {
     method: "DELETE",
   });
 


### PR DESCRIPTION
## 📝 Descripción
Este PR resuelve el **Issue #2** del repositorio. Se implementó una función envoltorio (`fetchWithAuth`) en el archivo de servicios de la API para interceptar las peticiones salientes e inyectar de forma automática el token JWT en las cabeceras.

## 🛠️ Cambios introducidos
- **Creado helper `fetchWithAuth`:** Una función encargada de leer el token desde el `localStorage` y adjuntar la cabecera `Authorization: Bearer <token>` si la sesión está activa.
- **Refactorización de `api.js`:** Se actualizaron todas las llamadas a la API (`getAll`, `getById`, `create`, `update` y `remove`) para que utilicen este nuevo envoltorio en lugar del `fetch` nativo del navegador.

## 🧪 ¿Cómo probarlo?
1. Inicia sesión en la aplicación (puedes usar el mock de `admin@admin.com` creado en el Issue #1 para guardar un token ficticio en el `localStorage`).
2. Realiza cualquier petición a la API y verifica en la pestaña **Network** (Red) del navegador que los request headers incluyan:
   `Authorization: Bearer <tu-token>`

---
*Closes #83 *